### PR TITLE
Parallelize njobs

### DIFF
--- a/example_configs/0.3.0/example_config.yaml
+++ b/example_configs/0.3.0/example_config.yaml
@@ -204,5 +204,6 @@ host_options:
       manager: 'local'
       launch_mode: 'dask_worker'  # This can only be serial or parallel, any other options will make it fail.
       # Arguments below only affect to parallel launch mode
+      njobs:  # This indicates the number of jobs LC will launc each time in parallel mode until finish your subSesList. If empty, LC will launch 2 jobs in parallel each time by default.
       memory_limit: '16GiB'  #
       threads_per_worker: 6  # 

--- a/src/prepare_inputs/utils.py
+++ b/src/prepare_inputs/utils.py
@@ -139,13 +139,17 @@ def read_yaml(path_to_config_file):
 
     container = config["general"]["container"]
     host = config["general"]["host"]
+    njobs = config["host_options"][host]["njobs"]
+    if njobs == "" or njobs is None:
+        njobs = 2
     host_str = f"{host}"
     if host == "local":
         launch_mode = config["host_options"]["local"]["launch_mode"]
         valid_options = ["serial", "parallel","dask_worker"]
         if launch_mode in valid_options:
             host_str = (
-                f"{host_str}, and commands will be launched in {launch_mode} mode. "
+                f"{host_str}, and commands will be launched in {launch_mode} mode "
+                f"every {njobs} jobs. "
                 f"Serial is safe but it will take longer. "
                 f"If you launch in parallel be aware that some of the "
                 f"processes might be killed if the limit (usually memory) "


### PR DESCRIPTION
With this update, the user can specify in the .yaml file the number of jobs (njobs) to be launched in parallel. Before, all jobs were launched together, now, the jobs will be launched every njobs.